### PR TITLE
multi-chain configuration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 0.0.7
+- new: Multi-Chain support - #8
+  - new setting `vscode-ethover.chain.config` (object). defaults see `package.json`. add new custom chain/network configurations using the same format. User config gets merged with defaults in code.
+- rename: setting `vscode-ethover.address.lookupUrl` (now configured with `vscode-ethover.chain.config`)
+- rename: setting `vscode-ethover.apikey` (and `apiurl`) to `vscode-ethover.default.apikey` (used for action links (bytecode etc.))
+- add: action bloxy.info
+
+![image](https://user-images.githubusercontent.com/2865694/143015504-fbfea586-4baa-44a7-84c3-dbf8a988838c.png)
+
+![image](https://user-images.githubusercontent.com/2865694/143015659-2899cf99-5eb5-4df1-8d2e-b14a12e39510.png)
+
+![image](https://user-images.githubusercontent.com/2865694/143015924-57fcbba1-74c8-4abd-9f8c-846daad588dd.png)
+
+
 ## 0.0.6
 - new: enable ethover for python files - #5
 

--- a/package.json
+++ b/package.json
@@ -125,7 +125,11 @@
                 },
                 "vscode-ethover.hover.getBalance": {
                     "type": "string",
-                    "enum": ["yes", "no", "yes-ask"],
+                    "enum": [
+                        "yes",
+                        "no",
+                        "yes-ask"
+                    ],
                     "description": "Fetch mainnet balance from etherscan.io? (Note: might require a valid ApiKey)",
                     "default": "yes-ask"
                 },
@@ -146,7 +150,7 @@
                             "enabled": true,
                             "apiurl": "https://api-ropsten.etherscan.io/api",
                             "apikey": "YourApiKeyToken",
-                            "url": "https://etherscan.io/address/{address}"
+                            "url": "https://ropsten.etherscan.io/address/{address}"
                         },
                         "kovan": {
                             "name": "Kovan",
@@ -165,20 +169,18 @@
                         "polygon": {
                             "name": "Polygon",
                             "enabled": true,
-                            "apiurl": "https://api-polygon.etherscan.io/api",
+                            "apiurl": "https://api.polygonscan.com/api",
                             "apikey": "YourApiKeyToken",
                             "url": "https://polygonscan.com/address/{address}"
                         }
-                        
                     }
                 }
-                
             }
         }
     },
     "dependencies": {
         "etherscan-api": "^10.0.5",
         "evm": "^0.2.0",
-        "table": "^5.4.6"
+        "table": "^6.7.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-ethover",
     "displayName": "ETHover",
     "description": "Ethereum Account Address Hover Info and Actions",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "keywords": [
         "solidity",
         "ethereum",
@@ -113,12 +113,12 @@
             "type": "object",
             "title": "ETHover",
             "properties": {
-                "vscode-ethover.address.lookupUrl": {
+                "vscode-ethover.default.apiurl": {
                     "type": "string",
-                    "description": "Service used to lookup ethereum addresses. Note: placeholder {address}",
-                    "default": "https://etherscan.io/address/{address}"
+                    "description": "The etherscan.io API endpoint to use.",
+                    "default": "https://api.etherscan.io/api"
                 },
-                "vscode-ethover.apikey": {
+                "vscode-ethover.default.apikey": {
                     "type": "string",
                     "description": "Your etherscan.io API key used when fetching Contract Source or Bytecode from etherscan.io.",
                     "default": "YourApiKeyToken"
@@ -128,7 +128,51 @@
                     "enum": ["yes", "no", "yes-ask"],
                     "description": "Fetch mainnet balance from etherscan.io? (Note: might require a valid ApiKey)",
                     "default": "yes-ask"
+                },
+                "vscode-ethover.chain.config": {
+                    "type": "object",
+                    "description": "Multi-Chain Network Configuration. See `package.json - vscode-ethover.chain.config` for how to customize.",
+                    "properties": {},
+                    "default": {
+                        "mainnet": {
+                            "name": "Mainnet",
+                            "enabled": true,
+                            "apiurl": "https://api.etherscan.io/api",
+                            "apikey": "YourApiKeyToken",
+                            "url": "https://etherscan.io/address/{address}"
+                        },
+                        "ropsten": {
+                            "name": "Ropsten",
+                            "enabled": true,
+                            "apiurl": "https://api-ropsten.etherscan.io/api",
+                            "apikey": "YourApiKeyToken",
+                            "url": "https://etherscan.io/address/{address}"
+                        },
+                        "kovan": {
+                            "name": "Kovan",
+                            "enabled": true,
+                            "apiurl": "https://api-kovan.etherscan.io/api",
+                            "apikey": "YourApiKeyToken",
+                            "url": "https://kovan.etherscan.io/address/{address}"
+                        },
+                        "rinkeby": {
+                            "name": "Rinkeby",
+                            "enabled": true,
+                            "apiurl": "https://api-rinkeby.etherscan.io/api",
+                            "apikey": "YourApiKeyToken",
+                            "url": "https://rinkeby.etherscan.io/address/{address}"
+                        },
+                        "polygon": {
+                            "name": "Polygon",
+                            "enabled": true,
+                            "apiurl": "https://api-polygon.etherscan.io/api",
+                            "apikey": "YourApiKeyToken",
+                            "url": "https://polygonscan.com/address/{address}"
+                        }
+                        
+                    }
                 }
+                
             }
         }
     },

--- a/src/extension.js
+++ b/src/extension.js
@@ -35,7 +35,7 @@ function openEvmTrace(uri) {
 /** event funcs */
 function onActivate(context) {
 
-    const etherscan = new EtherScanIo(settings.extensionConfig().apikey);
+    const etherscan = new EtherScanIo(settings.extensionConfig().default.apikey, settings.extensionConfig().default.apiurl);
 
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(DOC_SELECTOR, {
@@ -48,7 +48,7 @@ function onActivate(context) {
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(DOC_SELECTOR, {
             provideHover(document, position, token) {
-                return hover.provideBalanceHover(document, position, token, etherscan);
+                return hover.provideBalanceHover(document, position, token);
             }
         })
     );

--- a/src/features/etherscan.js
+++ b/src/features/etherscan.js
@@ -10,7 +10,8 @@ const http = require('https');
 
 class EtherScanIoConnector {
 
-    constructor(apikey) {
+    constructor(apikey, apiurl) {
+        this.apiurl = apiurl || "https://api.etherscan.io/api";
         this.apikey = apikey;
     }
 
@@ -24,7 +25,7 @@ class EtherScanIoConnector {
 
     etherscanRequest(cmd) {
         return new Promise((resolve, reject) => {
-            http.get(`https://api.etherscan.io/api?apikey=${this.apikey}&${cmd}`, (res) => {
+            http.get(`${this.apiurl}?apikey=${this.apikey}&${cmd}`, (res) => {
                 const { statusCode } = res;
                 const contentType = res.headers['content-type'];
 
@@ -69,8 +70,8 @@ class EtherScanIoConnector {
 
 class EtherScanIo extends EtherScanIoConnector {
 
-    constructor(apikey) {
-        super(apikey);
+    constructor(apikey, apiurl) {
+        super(apikey, apiurl);
         this.apikey = apikey || 'YourApiKeyToken';
         this.api = require('etherscan-api').init(this.apikey);
     }

--- a/src/features/etherscan.js
+++ b/src/features/etherscan.js
@@ -23,6 +23,10 @@ class EtherScanIoConnector {
         return this.etherscanRequest("module=proxy&action=eth_getCode&tag=latest&address=" + address);
     }
 
+    balanceForAddress(address) {
+        return this.etherscanRequest("module=account&action=balance&address=" + address + "&tag=latest");
+    }
+
     etherscanRequest(cmd) {
         return new Promise((resolve, reject) => {
             http.get(`${this.apiurl}?apikey=${this.apikey}&${cmd}`, (res) => {

--- a/src/features/hover.js
+++ b/src/features/hover.js
@@ -130,18 +130,25 @@ async function provideBalanceHover(document, position, token) {
         try {
             if(!balance){
                 let etherscan = new EtherScanIo(cconf.apiKey, cconf.apiurl);
-
-                balance = await etherscan.api.account.balance(address);
+                balance = await etherscan.balanceForAddress(address);
+                //balance = await etherscan.api.account.balance(address); //etherscanapi does not support custom chains
+                balance = parseInt(balance);
+                if(Number.isNaN(balance)){
+                    throw new Error(balance); //is an errormsg
+                }
                 CACHE.set(`balance_${cconf.name}`, address, balance);
             }
             addressHover.push(`([${cconf.name}](${cconf.url.replace("{address}",address)}))`);
-            totalBalance += balance.result;
+            totalBalance += balance;
         } catch(e) {
             errors.push(`Error: ${cconf.name} (\`${e}\`)`);
         }
     }
 
     addressHover.unshift(`∑ 💰 **${(totalBalance/ONE_ETH).toFixed(2)}** Ether `)
+    if(errors.length){
+        addressHover.push(`(\`rate limit error, try again\`)`);
+    }
 
     if(hoverEnabled=="yes-ask"){
         addressHover.push(` |  ([settings](${makeCommandUri('workbench.action.openSettings', `vscode-ethover.hover.getBalance`)}))`);

--- a/src/features/hover.js
+++ b/src/features/hover.js
@@ -138,7 +138,7 @@ async function provideBalanceHover(document, position, token) {
                 }
                 CACHE.set(`balance_${cconf.name}`, address, balance);
             }
-            addressHover.push(`([${cconf.name}](${cconf.url.replace("{address}",address)}))`);
+            addressHover.push(`(${balance >0 ? '•' : ''}[${cconf.name}](${cconf.url.replace("{address}",address)}))`);
             totalBalance += balance;
         } catch(e) {
             errors.push(`Error: ${cconf.name} (\`${e}\`)`);


### PR DESCRIPTION
fixes #6 

* code refactoring to allow multi-chain configuration. new setting `vscode-ethover.chain.config` (object). defaults see `package.json`.
  * add new custom chain/network configurations using the same format. User config gets merged with defaults in code.
* removed setting `vscode-ethover.address.lookupUrl`
* renamed setting `vscode-ethover.apikey` (and `apiurl`) to `vscode-ethover.default.apikey` (this is for bytecode fetching. etc.)
* added bloxy.info

### new config option

![image](https://user-images.githubusercontent.com/2865694/143015659-2899cf99-5eb5-4df1-8d2e-b14a12e39510.png)

### Defaults

![image](https://user-images.githubusercontent.com/2865694/143015924-57fcbba1-74c8-4abd-9f8c-846daad588dd.png)

### MultiChain hover

![image](https://user-images.githubusercontent.com/2865694/143015504-fbfea586-4baa-44a7-84c3-dbf8a988838c.png)